### PR TITLE
Update for 2024 interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The app was built using Node.js 18.  To get it running, do:
 
 ```sh
 $ npm ci
+$ npm run db:create
+$ npm run db:populate
 $ npm start
 ```
 

--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ app.use(morgan('dev')); // Request logger
 
 [
     'health',
-    'network',
     'petitions',
 ].forEach((route) => {
     require(`./routes/${route}`)(app);

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1,3 +1,5 @@
+
+
 const fs = require('fs');
 const zipObject = require('lodash/zipObject');
 const initSqlJs = require('sql.js');
@@ -10,11 +12,18 @@ async function getConnection() {
 
 async function runQuery(sqlStatement) {
     const db = await getConnection();
-    const [{ columns, values }] = db.exec(sqlStatement);
-    return values.map((record) => zipObject(columns, record));
+    const response = db.exec(sqlStatement);
+
+    if (response.length) {
+        const [{ columns, values }] = response;
+        return values.map((record) => zipObject(columns, record));
+    } else {
+        return [];
+    }
 }
 
 module.exports = {
     getConnection,
     runQuery,
 };
+

--- a/routes/network.js
+++ b/routes/network.js
@@ -1,9 +1,0 @@
-const jsonPromiseHandler = require('../lib/jsonPromiseHandler');
-
-async function getNetwork(req) {
-    return [];
-}
-
-module.exports = (app) => {
-    app.get('/network', jsonPromiseHandler(getNetwork));
-};


### PR DESCRIPTION
Removing `/network` since creating a new endpoint and appropriately naming it is something to check for.

Also fixing some "bugs". We can discuss whether to merge or leave as is - leaving as is could be good opportunities to see how candidates handle debugging unexpected problems, or whether they find creative workarounds or get stuck on the problem.

README:
- Includes prompt to regenerate data, so that `created_at` include dates from the past week (for the task to find petitions from the past week). 

sql.js:
- When the SQL statement returns an empty result, there is an error about "column" being undefined. The Rails version doesn't have this problem, so fixing this would make both versions consistent.