### PR TITLE
fix always green test

### DIFF
--- a/routes/__tests__/petitions.test.js
+++ b/routes/__tests__/petitions.test.js
@@ -1,9 +1,9 @@
-const app = require('../../app');
-const request = require('supertest');
+const app = require("../../app");
+const request = require("supertest");
 
-describe('/petitions', () => {
-    test('it passes', async () => {
-        const response = await request(app).get('/petitions');
-        expect(!!response).toBe(true);
-    });
+describe("/petitions", () => {
+  test("it is available", async () => {
+    const response = await request(app).get("/petitions");
+    expect(response.status).toBe(200);
+  });
 });


### PR DESCRIPTION
The current test is still green even when hitting a non existing endpoint.
Expecting status 200 explicitly ensures the endpoint exists.